### PR TITLE
入退職のタスクの作成

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,10 +1,9 @@
 class CompaniesController < ApplicationController
   before_action :set_company
 
-def index
-  @company = current_company
-end
-
+  def index
+    @company = current_company
+  end
 
   def edit
   end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -5,6 +5,13 @@ class EmployeesController < ApplicationController
     @employees = Employee.where(company_id: current_company.id) #後ほど社員No.順になるようにorderを追記
   end
 
+  def task
+    @employees = Employee.where(company_id: current_company.id)
+    @social_insurance_acquisition_procedures\
+      = @employees.where(social_insurance_condition: 1)
+    @employment_insurance_acquisition_procedures\
+      = @employees.where(employment_insurance_condition: 1)
+  end
 
   def new
     @employee = Employee.new

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -13,6 +13,24 @@ class EmployeesController < ApplicationController
       = @employees.where(employment_insurance_condition: 1)
   end
 
+  def task_completed_social_insurance
+    @employee = Employee.find(params[:id])
+    if @employee.update(social_insurance_condition: 2)
+      redirect_to task_employees_path
+    else
+      render :task
+    end
+  end
+
+  def task_completed_employment_insurance
+    @employee = Employee.find(params[:id])
+    if @employee.update(employment_insurance_condition: 2)
+      redirect_to task_employees_path
+    else
+      render :task
+    end
+  end
+
   def new
     @employee = Employee.new
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,4 +7,23 @@ class Employee < ApplicationRecord
   enum sex: {"男":0, "女":1}
   enum pay_type: {"月給":0, "時給":1, "日給":2, "その他":3}
   
+
+  after_create do #社保雇保の手続き要否を判断しカラムに追記する
+    if working_hours.blank? #週労働時間がblankの場合
+      self.update(social_insurance_condition: 0, employment_insurance_condition: 0) #社保雇保共に手続き不要
+    else 
+      if working_hours >= 30 #社会保険加入条件
+        self.update(social_insurance_condition: 1) #条件を満たせば社保手続が必要
+      else
+        self.update(social_insurance_condition: 0) #条件を満たさないので社保手続不要
+      end
+      if working_hours >= 20 #雇用保険加入条件
+        self.update(employment_insurance_condition: 1) #条件を満たせば雇保手続が必要
+      else
+        self.update(employment_insurance_condition: 0) #条件を満たさないので雇保手続不要
+      end
+    end
+  end
+
+
 end

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -3,4 +3,4 @@
 .list
   =link_to "従業員登録", new_employee_path
 .list
-  =link_to "タスク", "#"
+  =link_to "タスク", task_employees_path

--- a/app/views/employees/index.html.haml
+++ b/app/views/employees/index.html.haml
@@ -2,7 +2,7 @@
 .employee__index
   - @employees.each do |employee|
     .employee__index__employee__name
-      = link_to edit_employee_path(employee.id) do
+      = link_to edit_employee_path(employee) do
         =employee.family_name
         =employee.first_name
         

--- a/app/views/employees/task.html.haml
+++ b/app/views/employees/task.html.haml
@@ -10,9 +10,9 @@
           .task__employee__name
             =employee.family_name
             =employee.first_name
-
-
-
+        .task__completed
+          = form_with model: employee, url: task_completed_social_insurance_employee_path(employee), method: "patch" do |f|
+            = f.submit "手続済にする"
 
     .task__acquisition__employment_insurance
       雇用保険資格取得手続
@@ -23,6 +23,11 @@
           .task__employee__name
             =employee.family_name
             =employee.first_name
+        .task__completed
+          = form_with model: employee, url: task_completed_employment_insurance_employee_path(employee), method: "patch" do |f|
+            = f.submit "手続済にする"
+
+
 
 
 

--- a/app/views/employees/task.html.haml
+++ b/app/views/employees/task.html.haml
@@ -1,0 +1,28 @@
+-# タスクページ
+.task
+  .task__acquisition
+    .task__acquisition__social_insurance
+      社会保険資格取得手続
+      - @social_insurance_acquisition_procedures.each do |employee|
+        = link_to "#" do
+          .task__acquisition_date
+            =employee.social_insurance_acquisition_date
+          .task__employee__name
+            =employee.family_name
+            =employee.first_name
+
+
+
+
+    .task__acquisition__employment_insurance
+      雇用保険資格取得手続
+      - @employment_insurance_acquisition_procedures.each do |employee|
+        = link_to "#" do
+          .task__acquisition_date
+            =employee.employment_insurance_acquisition_date
+          .task__employee__name
+            =employee.family_name
+            =employee.first_name
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,10 @@ Rails.application.routes.draw do
   root 'companies#index'
   resources :companies, only: [:edit, :update]
   resources :employees, only: [:index, :new, :create, :edit, :update] do
-    collection do
-      get 'task'
-    end
+    get 'task', on: :collection
+    patch 'task_completed_social_insurance', on: :member
+    patch 'task_completed_employment_insurance', on: :member
+
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
 
   root 'companies#index'
   resources :companies, only: [:edit, :update]
-  resources :employees, only: [:index, :new, :create, :edit, :update]
+  resources :employees, only: [:index, :new, :create, :edit, :update] do
+    collection do
+      get 'task'
+    end
+  end
 
 end

--- a/db/migrate/20200119053758_create_employees.rb
+++ b/db/migrate/20200119053758_create_employees.rb
@@ -27,9 +27,11 @@ class CreateEmployees < ActiveRecord::Migration[6.0]
       t.integer :monthly_remuneration
       t.integer :standard_monthly_remuneration
       t.date    :social_insurance_acquisition_date
+      t.integer :social_insurance_condition
       t.integer :health_insurance_number
       t.integer :basic_pension_number
       t.date    :employment_insurance_acquisition_date
+      t.integer :employment_insurance_condition
       t.integer :employment_insurance_number
       t.text    :image
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(version: 2020_01_19_053758) do
     t.text "image"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "social_insurance_condition"
+    t.integer "employment_insurance_condition"
     t.index ["company_id"], name: "index_employees_on_company_id"
     t.index ["family_name"], name: "index_employees_on_family_name"
     t.index ["family_name_f"], name: "index_employees_on_family_name_f"


### PR DESCRIPTION
#WHAT 
1. employeesテーブルに社会保険と雇用保険の手続要否を記録するカラムを追加
1. 従業員情報新規登録後に手続要否を判断する機能
1. タスク一覧（取得手続）の表示
1. 手続完了ボタンの表示

#WHY 
アプリケーション側で、新規登録従業員の手続要否を判断し、ユーザーに示すため
