### PR TITLE
トップページへのリンクの設定

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,6 +1,7 @@
 .header
   .header__name
-    = @company.name
+    = link_to root_path do
+      = @company.name
 
   .header__edit
     - if company_signed_in?


### PR DESCRIPTION
#WHAT 
1. ヘッダーの会社名からトップページへ遷移

#WHY 
どのページからでもトップページへ遷移できるようにするため
