### PR TITLE
従業員テーブルのカラムの追加・変更

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -9,23 +9,23 @@ class EmployeesController < ApplicationController
   def task
     @employees = Employee.where(company_id: current_company.id)
     @social_insurance_acquisition_procedures\
-      = @employees.where(social_insurance_condition: 1).order('social_insurance_acquisition_date ASC')
+      = @employees.where(social_insurance_condition_acquisition: 1).order('social_insurance_acquisition_date ASC')
     @employment_insurance_acquisition_procedures\
-      = @employees.where(employment_insurance_condition: 1).order('employment_insurance_acquisition_date ASC')
+      = @employees.where(employment_insurance_condition_acquisition: 1).order('employment_insurance_acquisition_date ASC')
   end
 
-  def task_completed_social_insurance
+  def task_completed_social_insurance_acquisition
     @employee = Employee.find(params[:id])
-    if @employee.update(social_insurance_condition: 2)
+    if @employee.update(social_insurance_condition_acquisition: 2)
       redirect_to task_employees_path
     else
       render :task
     end
   end
 
-  def task_completed_employment_insurance
+  def task_completed_employment_insurance_acquisition
     @employee = Employee.find(params[:id])
-    if @employee.update(employment_insurance_condition: 2)
+    if @employee.update(employment_insurance_condition_acquisition: 2)
       redirect_to task_employees_path
     else
       render :task

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -2,7 +2,9 @@ class Employee < ApplicationRecord
   belongs_to :company
   mount_uploader :image, ImageUploader
 
-  validates :family_name_f,:first_name_f, presence: true, format: { with: /[\u{ff66}-\u{ff9f}]/ }
+  validates :family_name_f, :first_name_f, allow_blank: true, format: { with: /[\u{ff66}-\u{ff9f}]/ }
+  validates :basic_pension_number, allow_blank: true, length: { minimum: 10, maximum: 10 }
+  validates :employment_insurance_number, allow_blank: true, length: { minimum: 11, maximum: 11 }
 
   enum sex: {"男":0, "女":1}
   enum pay_type: {"月給":0, "時給":1, "日給":2, "その他":3}
@@ -10,17 +12,17 @@ class Employee < ApplicationRecord
 
   after_create do #社保雇保の手続き要否を判断しカラムに追記する
     if working_hours.blank? #週労働時間がblankの場合
-      self.update(social_insurance_condition: 0, employment_insurance_condition: 0) #社保雇保共に手続き不要
+      self.update(social_insurance_condition_acquisition: 0, employment_insurance_condition_acquisition: 0) #社保雇保共に手続き不要
     else 
       if working_hours >= 30 #社会保険加入条件
-        self.update(social_insurance_condition: 1) #条件を満たせば社保手続が必要
+        self.update(social_insurance_condition_acquisition: 1) #条件を満たせば社保手続が必要
       else
-        self.update(social_insurance_condition: 0) #条件を満たさないので社保手続不要
+        self.update(social_insurance_condition_acquisition: 0) #条件を満たさないので社保手続不要
       end
       if working_hours >= 20 #雇用保険加入条件
-        self.update(employment_insurance_condition: 1) #条件を満たせば雇保手続が必要
+        self.update(employment_insurance_condition_acquisition: 1) #条件を満たせば雇保手続が必要
       else
-        self.update(employment_insurance_condition: 0) #条件を満たさないので雇保手続不要
+        self.update(employment_insurance_condition_acquisition: 0) #条件を満たさないので雇保手続不要
       end
     end
   end

--- a/app/views/employees/_employee_form.html.haml
+++ b/app/views/employees/_employee_form.html.haml
@@ -5,7 +5,7 @@
       .employee-form__center__employee_id
         .employee-form__center__employee_id__title
           従業員NO.
-        = f.text_field :employee_id, class: "employee-form__center__employee_id__form form"
+        = f.number_field :employee_id, class: "employee-form__center__employee_id__form form"
       .employee-form__center__name
         .employee-form__center__name__kanji
           .employee-form__center__name__kanji__title

--- a/app/views/employees/task.html.haml
+++ b/app/views/employees/task.html.haml
@@ -19,7 +19,7 @@
                 .task__center__acquisition__social_insurance__table__data__left__name
                   = employee.family_name + " " + employee.first_name
               .task__center__acquisition__social_insurance__table__data__right
-                = form_with model: employee, url: task_completed_social_insurance_employee_path(employee), method: "patch" do |f|
+                = form_with model: employee, url: task_completed_social_insurance_acquisition_employee_path(employee), method: "patch" do |f|
                   = f.submit "手続済にする", class: "task__center__acquisition__social_insurance__table__data__right__submit"
       .task__center__acquisition__employment_insurance
         .task__center__acquisition__employment_insurance__title
@@ -38,5 +38,5 @@
                 .task__center__acquisition__employment_insurance__table__data__left__name
                   = employee.family_name + " " + employee.first_name
               .task__center__acquisition__employment_insurance__table__data__right
-                = form_with model: employee, url: task_completed_employment_insurance_employee_path(employee), method: "patch" do |f|
+                = form_with model: employee, url: task_completed_employment_insurance_acquisition_employee_path(employee), method: "patch" do |f|
                   = f.submit "手続済にする", class: "task__center__acquisition__employment_insurance__table__data__right__submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
   resources :companies, only: [:edit, :update]
   resources :employees, only: [:index, :new, :create, :edit, :update] do
     get 'task', on: :collection
-    patch 'task_completed_social_insurance', on: :member
-    patch 'task_completed_employment_insurance', on: :member
+    patch 'task_completed_social_insurance_acquisition', on: :member
+    patch 'task_completed_employment_insurance_acquisition', on: :member
 
   end
 

--- a/db/migrate/20200119053758_create_employees.rb
+++ b/db/migrate/20200119053758_create_employees.rb
@@ -2,19 +2,19 @@ class CreateEmployees < ActiveRecord::Migration[6.0]
   def change
     create_table :employees do |t|
       t.references :company, foreign_key: true
-      t.string  :family_name,        null: false, index: true
-      t.string  :first_name,         null: false, index: true
-      t.string  :family_name_f,      null: false, index: true
-      t.string  :first_name_f,       null: false, index: true
-      t.date    :birthday,           null: false
-      t.integer :sex,                null: false
+      t.string  :family_name
+      t.string  :first_name
+      t.string  :family_name_f
+      t.string  :first_name_f
+      t.date    :birthday
+      t.integer :sex
       t.integer :postal_code
       t.text    :address
       t.text    :address_f
       t.date    :hire_date
       t.date    :retirement_date
       t.string  :reason_for_retirement
-      t.string  :employee_id,        unique: true 
+      t.integer :employee_id
       t.string  :employment_status
       t.string  :department
       t.integer :working_hours
@@ -27,12 +27,16 @@ class CreateEmployees < ActiveRecord::Migration[6.0]
       t.integer :monthly_remuneration
       t.integer :standard_monthly_remuneration
       t.date    :social_insurance_acquisition_date
-      t.integer :social_insurance_condition
+      t.date    :social_insurance_disqualification_date
+      t.integer :social_insurance_condition_acquisition
+      t.integer :social_insurance_condition_disqualification
       t.integer :health_insurance_number
-      t.integer :basic_pension_number
+      t.bigint  :basic_pension_number
       t.date    :employment_insurance_acquisition_date
-      t.integer :employment_insurance_condition
-      t.integer :employment_insurance_number
+      t.date    :employment_insurance_disqualification_date
+      t.integer :employment_insurance_condition_acquisition
+      t.integer :employment_insurance_condition_disqualification
+      t.bigint  :employment_insurance_number
       t.text    :image
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,19 +30,19 @@ ActiveRecord::Schema.define(version: 2020_01_19_053758) do
 
   create_table "employees", force: :cascade do |t|
     t.bigint "company_id"
-    t.string "family_name", null: false
-    t.string "first_name", null: false
-    t.string "family_name_f", null: false
-    t.string "first_name_f", null: false
-    t.date "birthday", null: false
-    t.integer "sex", null: false
+    t.string "family_name"
+    t.string "first_name"
+    t.string "family_name_f"
+    t.string "first_name_f"
+    t.date "birthday"
+    t.integer "sex"
     t.integer "postal_code"
     t.text "address"
     t.text "address_f"
     t.date "hire_date"
     t.date "retirement_date"
     t.string "reason_for_retirement"
-    t.string "employee_id"
+    t.integer "employee_id"
     t.string "employment_status"
     t.string "department"
     t.integer "working_hours"
@@ -55,20 +55,20 @@ ActiveRecord::Schema.define(version: 2020_01_19_053758) do
     t.integer "monthly_remuneration"
     t.integer "standard_monthly_remuneration"
     t.date "social_insurance_acquisition_date"
+    t.date "social_insurance_disqualification_date"
+    t.integer "social_insurance_condition_acquisition"
+    t.integer "social_insurance_condition_disqualification"
     t.integer "health_insurance_number"
-    t.integer "basic_pension_number"
+    t.bigint "basic_pension_number"
     t.date "employment_insurance_acquisition_date"
-    t.integer "employment_insurance_number"
+    t.date "employment_insurance_disqualification_date"
+    t.integer "employment_insurance_condition_acquisition"
+    t.integer "employment_insurance_condition_disqualification"
+    t.bigint "employment_insurance_number"
     t.text "image"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "social_insurance_condition"
-    t.integer "employment_insurance_condition"
     t.index ["company_id"], name: "index_employees_on_company_id"
-    t.index ["family_name"], name: "index_employees_on_family_name"
-    t.index ["family_name_f"], name: "index_employees_on_family_name_f"
-    t.index ["first_name"], name: "index_employees_on_first_name"
-    t.index ["first_name_f"], name: "index_employees_on_first_name_f"
   end
 
   add_foreign_key "employees", "companies"


### PR DESCRIPTION
#WHAT 
1. employee_idを数値で保存
1. 退職に関するカラムの追加
1. 被保険者番号をbigintで保存
1. 上記変更に合わせて、フォームやルートの修正

#WHY 
1. カラムの型が正しくなかったため
1. 退職に関するタスクを作成するため